### PR TITLE
fix: race condition on clickhouse and coa-core

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - .volumes/clickhouse/data:/var/lib/clickhouse
       - ./config/clickhouse/initdb.d:/docker-entrypoint-initdb.d:ro
     healthcheck:
-      test: [ "CMD", "clickhouse-client", "--query", "SELECT 1" ]
+      test: [ "CMD", "clickhouse-client", "--user", "coagent", "--password", "coagent", "--database", "coagent", "--query", "SELECT 1" ]
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
- Health check starts right away instead of consistently delaying 30s
- Ensures the database `coagent` exists in ClickHouse as part of the health check
